### PR TITLE
Added new picasaGallery function options to customize fancyBox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## jQuery Picasa Gallery v1.0
-jQuery plugin that displays your public picasa web albums on your website in a photo gallery.
+jQuery plugin that displays your public picasa/google+ web albums on your website in a photo gallery.
 
 ### Example
 <http://alanhamlett.github.com/jQuery-Picasa-Gallery>

--- a/example.html
+++ b/example.html
@@ -7,6 +7,7 @@
         <link href="./jquery.picasagallery.css" rel="stylesheet" type="text/css" media="screen" />
         <link href="./fancyBox/helpers/jquery.fancybox-thumbs.css?v=2.0.5" rel="stylesheet" type="text/css" media="screen" />
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
+        <script src="./fancyBox/jquery.mousewheel-3.0.6.pack.js" type="text/javascript"></script>
         <script src="./fancyBox/jquery.fancybox.pack.js?v=2.0.5" type="text/javascript"></script>
         <script src="./fancyBox/helpers/jquery.fancybox-thumbs.js?v=2.0.5" type="text/javascript"></script>
         <script src="./jquery.picasagallery.js" type="text/javascript"></script>
@@ -30,13 +31,19 @@
         <p><pre style="border:1px solid #B6C5CF; background:#CADBE6;">$(document).ready( function() { $('.picasagallery').picasagallery( {username:'alan.hamlett'} ); } );</pre></p>
         <p>Default Options:</p>
         <p><pre style="border:1px solid #B6C5CF; background:#CADBE6;">{
-    username: '', // Your Picasa public username
+    username: '', // Your Picasa public username or your Google+ User ID (e.g. https://plus.google.com/u/0/b/this-is-your-user-id)
     hide_albums: ['Profile Photos', 'Scrapbook Photos', 'Instant Upload', 'Photos from posts'], // hidden album names
     link_to_picasa: false, // true to display link to original album on Google Picasa
     thumbnail_width: '160', // width of album and photo thumbnails
     thumbnail_cropped: false, // use cropped format (square)
     title: 'Picasa Photo Gallery', // title shown above album list
     inline: false, // true to display photos inline instead of using the fancybox plugin
+    auto_open: false, // true to automatically open fancyBox for the first photo in the album
+    loaded: false, // true if data was already loaded. false will enable retrieval of data while true will assume that data has been loaded already.
+    mouseWheel: false, // fancyBox setting. If set to true, you will be able to navigate gallery using the mouse wheel
+    arrows: true, // fancyBox setting. If set to true, fancyBox will display arrows
+    closeClick: false, // fancyBox setting. If set to true, fancyBox will be closed when user clicks the content
+    closeBtn: true // fancyBox setting. If set to true, fancyBox will display a close button
 }</pre><p>
     </div>
     </body>

--- a/fancyBox/jquery.mousewheel-3.0.6.pack.js
+++ b/fancyBox/jquery.mousewheel-3.0.6.pack.js
@@ -1,0 +1,13 @@
+/*! Copyright (c) 2011 Brandon Aaron (http://brandonaaron.net)
+ * Licensed under the MIT License (LICENSE.txt).
+ *
+ * Thanks to: http://adomas.org/javascript-mouse-wheel/ for some pointers.
+ * Thanks to: Mathias Bank(http://www.mathias-bank.de) for a scope bug fix.
+ * Thanks to: Seamus Leahy for adding deltaX and deltaY
+ *
+ * Version: 3.0.6
+ * 
+ * Requires: 1.2.2+
+ */
+(function(d){function e(a){var b=a||window.event,c=[].slice.call(arguments,1),f=0,e=0,g=0,a=d.event.fix(b);a.type="mousewheel";b.wheelDelta&&(f=b.wheelDelta/120);b.detail&&(f=-b.detail/3);g=f;b.axis!==void 0&&b.axis===b.HORIZONTAL_AXIS&&(g=0,e=-1*f);b.wheelDeltaY!==void 0&&(g=b.wheelDeltaY/120);b.wheelDeltaX!==void 0&&(e=-1*b.wheelDeltaX/120);c.unshift(a,f,e,g);return(d.event.dispatch||d.event.handle).apply(this,c)}var c=["DOMMouseScroll","mousewheel"];if(d.event.fixHooks)for(var h=c.length;h;)d.event.fixHooks[c[--h]]=
+d.event.mouseHooks;d.event.special.mousewheel={setup:function(){if(this.addEventListener)for(var a=c.length;a;)this.addEventListener(c[--a],e,false);else this.onmousewheel=e},teardown:function(){if(this.removeEventListener)for(var a=c.length;a;)this.removeEventListener(c[--a],e,false);else this.onmousewheel=null}};d.fn.extend({mousewheel:function(a){return a?this.bind("mousewheel",a):this.trigger("mousewheel")},unmousewheel:function(a){return this.unbind("mousewheel",a)}})})(jQuery);

--- a/jquery.picasagallery.js
+++ b/jquery.picasagallery.js
@@ -176,8 +176,10 @@
                 });
             } else {
                 $("a[rel=picasagallery_thumbnail]").fancybox({
-                    closeClick        : false, // If set to true, fancyBox will be closed when user clicks the content
-                    mouseWheel        : false, // If set to true, you will be able to navigate gallery using the mouse wheel
+                    closeClick        : data.closeClick, // If set to true, fancyBox will be closed when user clicks the content
+                    closeBtn          : data.closeBtn, // If set to true, fancyBox will display a close button
+                    mouseWheel        : data.mouseWheel, // If set to true, you will be able to navigate gallery using the mouse wheel
+                    arrows            : data.arrows, // If set to true, fancyBox will display arrows
                     loop              : true, // If set to true, enables cyclic navigation. This means, if you click "next" after you reach the last element, first element will be displayed (and vice versa).
                     openEffect        : 'elastic', // Animation effect ('elastic', 'fade' or 'none')
                     closeEffect       : 'elastic', // Animation effect ('elastic', 'fade' or 'none')
@@ -228,7 +230,11 @@
             'title': 'Photos',
             'inline': false,
             'auto_open': false,
-            'loaded': false
+            'loaded': false,
+            'mouseWheel': false, // fancyBox setting
+            'arrows': true, // fancyBox setting
+            'closeClick': false, // fancyBox setting
+            'closeBtn': true // fancyBox setting
         }, options));
         if (this.data('picasagallery') === undefined) {
             picasagallery_error('Cannot call method \'picasagallery\' of undefined. Must be called on a jQuery DOM object.');


### PR DESCRIPTION
Added function options include mouseWheel, arrows, closeClick, closeBtn.
Included jquery.mousewheel-3.0.6.pack.js for mousewheel functionality to work.
Also updated the example page for added documentation for the added option info.
Note: Google+ Photos are currently compatible with jQuery-Picasa-Gallery.
